### PR TITLE
[FEAT]market API 연결

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -2,37 +2,29 @@ import React, { useState } from "react";
 import { RouterProvider, Route, Routes, BrowserRouter } from "react-router-dom";
 import { routerObj } from "./routers/router";
 import "./index.css";
+import { Provider } from "react-redux";
+import store from "./store/store";
 
 function renderRoutes(routesObj) {
     return routesObj.map((route) => {
         if (route.children) {
             return (
-                <Route
-                    key={route.path}
-                    path={route.path}
-                    index={route.index}
-                    element={route.element}
-                >
+                <Route key={route.path} path={route.path} index={route.index} element={route.element}>
                     {route.children ? renderRoutes(route.children) : null}
                 </Route>
             );
         }
-        return (
-            <Route
-                key={route.path}
-                path={route.path}
-                index={route.index}
-                element={route.element}
-            />
-        );
+        return <Route key={route.path} path={route.path} index={route.index} element={route.element} />;
     });
 }
 
 function App() {
     return (
-        <BrowserRouter>
-            <Routes>{renderRoutes(routerObj)}</Routes>
-        </BrowserRouter>
+        <Provider store={store}>
+            <BrowserRouter>
+                <Routes>{renderRoutes(routerObj)}</Routes>
+            </BrowserRouter>
+        </Provider>
     );
 }
 

--- a/front/src/components/Ranking/Ranking.jsx
+++ b/front/src/components/Ranking/Ranking.jsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from "react";
 import RankComponent from "./RankComponent";
 import trophy from "~/public/imgs/trophy.png";
+import { GetRanking } from "../../lib/apis/stock";
 
 export default function Ranking() {
-    const users = [
+    const [users, setUsers] = useState([
         {
             nickname: "닉네임은여덟글자",
             stock_returns: 25.88,
@@ -28,12 +30,25 @@ export default function Ranking() {
             stock_returns: 23,
             profile_img: "",
         },
-    ];
-    const my = {
+    ]);
+    const [my, setMy] = useState({
         nickname: "닉네임은여덟글자",
         stock_returns: 23,
         profile_img: "",
-    };
+    });
+
+    useEffect(() => {
+        GetRanking(10)
+            .then((data) => {
+                if (data.top5[0]) {
+                    setUsers(data?.top5);
+                }
+                if (data.amI[0]) {
+                    setMy(data?.amI);
+                }
+            })
+            .catch((err) => console.log(err.response));
+    }, []);
 
     return (
         <div className="row-span-2 bg-back-yellow px-2 py-3 grid content-between">
@@ -43,7 +58,7 @@ export default function Ranking() {
                     <p className="text-2xl text-center">랭 킹</p>
                 </div>
                 <div className="flex flex-col space-y-2">
-                    {users.map((el, i) => (
+                    {users?.map((el, i) => (
                         <RankComponent user={el} rank={i + 1} key={i} />
                     ))}
                 </div>

--- a/front/src/components/StockCard.jsx
+++ b/front/src/components/StockCard.jsx
@@ -14,7 +14,7 @@ export default function StockCard(props) {
         >
             <div className="w-9 h-9 rounded-full bg-black"></div>
             <div className="text-sm min-w-[100px]">
-                <p className={selected == name && "text-white"}>{name}</p>
+                <p className={selected == name ? "text-white" : ""}>{name}</p>
                 <div
                     className={
                         diff >= 0 ? "text-shinhan-red flex justify-between" : "text-shinhan-blue flex justify-between"

--- a/front/src/components/StockCard.jsx
+++ b/front/src/components/StockCard.jsx
@@ -1,31 +1,29 @@
 import { IoTriangleSharp } from "react-icons/io5";
 
 export default function StockCard(props) {
-    const { title, price, change, value } = props.stock;
+    const { name, price, diff } = props.stock;
     const selected = props.selected;
     const onClick = props.onClick;
 
     return (
         <div
             className={`${
-                selected == title ? "bg-select-green" : "bg-white"
+                selected == name ? "bg-select-green" : "bg-white"
             } w-full rounded-3xl flex items-center space-x-2 justify-center px-3 space-x-2 hover:cursor-pointer hover:bg-select-green max-w-[180px]`}
             onClick={onClick}
         >
             <div className="w-9 h-9 rounded-full bg-black"></div>
             <div className="text-sm min-w-[100px]">
-                <p className={selected == title && "text-white"}>{title}</p>
+                <p className={selected == name && "text-white"}>{name}</p>
                 <div
                     className={
-                        change == "up"
-                            ? "text-shinhan-red flex justify-between"
-                            : "text-shinhan-blue flex justify-between"
+                        diff >= 0 ? "text-shinhan-red flex justify-between" : "text-shinhan-blue flex justify-between"
                     }
                 >
                     <span>{price.toLocaleString()}</span>
                     <div className="flex items-center ml-2">
-                        <IoTriangleSharp className={change == "down" && "rotate-180"} />
-                        <span className="min-w-[34px] text-right">{value}</span>
+                        <IoTriangleSharp className={diff <= 0 && "rotate-180"} />
+                        <span className="min-w-[34px] text-right">{Math.abs(diff).toLocaleString()}</span>
                     </div>
                 </div>
             </div>

--- a/front/src/components/StockChart.jsx
+++ b/front/src/components/StockChart.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import ReactApexChart from 'react-apexcharts';
+import React, { useEffect, useState } from "react";
+import ReactApexChart from "react-apexcharts";
+import { useSelector } from "react-redux";
 
 //
 const StockChart = () => {
-  /*
+    /*
   // 차트 데이터 예시
   // name: 데이터 값의 이름
   // data: 데이터 값 입력해주세용
@@ -18,48 +19,60 @@ const StockChart = () => {
   categories: [],
 
   */
-  const [chartOptions, setChartOptions] = useState({
-    series: [{
-      name: "Desktops",
-      data: [10, 41, 35, 51, 49, 62, 69, 91, 148]
-    }],
-    options: {
-      chart: {
-        height: 350,
-        type: 'line',
-        zoom: {
-          enabled: false
-        }
-      },
-      dataLabels: {
-        enabled: false
-      },
-      stroke: {
-        curve: 'straight'
-      },
-      title: {
-        text: 'Product Trends by Month',
-        align: 'left'
-      },
-      grid: {
-        row: {
-          colors: ['#f3f3f3', 'transparent'], // takes an array which will be repeated on columns
-          opacity: 0.5
+    const prices = useSelector((state) => state.stock.prices);
+    const [chartOptions, setChartOptions] = useState({
+        series: [
+            {
+                name: "Desktops",
+                data: [],
+            },
+        ],
+        options: {
+            chart: {
+                height: "auto",
+                type: "line",
+                zoom: {
+                    enabled: false,
+                },
+            },
+            dataLabels: {
+                enabled: false,
+            },
+            stroke: {
+                curve: "straight",
+            },
+            grid: {
+                row: {
+                    colors: ["#f3f3f3", "transparent"], // takes an array which will be repeated on columns
+                    opacity: 0.5,
+                },
+            },
+            xaxis: {
+                categories: ["D-5", "D-4", "D-3", "D-2", "D-1"],
+            },
+            colors: ["#88C9A1"],
         },
-      },
-      xaxis: {
-        categories: ['D-7', 'D-6', 'D-5', 'D-4', 'D-3', 'D-2', 'D-1', 'D-0'],
-      }
-    }
-  });
+    });
 
-  return (
-    <div>
-      <div id="chart">
-        <ReactApexChart options={chartOptions.options} series={chartOptions.series} type="line" height={350} />
-      </div>
-      <div id="html-dist"></div>
-    </div>
-  );
-}
+    useEffect(() => {
+        setChartOptions((prevOptions) => ({
+            ...prevOptions,
+            series: [
+                {
+                    ...prevOptions.series[0],
+                    data: prices,
+                },
+            ],
+        }));
+    }, [prices]);
+
+    return (
+        <div>
+            <div id="chart">
+                <ReactApexChart options={chartOptions.options} series={chartOptions.series} type="line" height={300} />
+            </div>
+            <div id="html-dist"></div>
+        </div>
+    );
+};
 export default StockChart;

--- a/front/src/components/StockChart.jsx
+++ b/front/src/components/StockChart.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import ReactApexChart from "react-apexcharts";
 import { useSelector } from "react-redux";
 
-//
 const StockChart = () => {
     /*
   // 차트 데이터 예시

--- a/front/src/components/StockDetail.jsx
+++ b/front/src/components/StockDetail.jsx
@@ -33,7 +33,7 @@ export default function StockDetail({ stock }) {
                 <div className="w-20 h-20 bg-black rounded-full"></div>
                 <p>여기 회사 설명할거임</p>
             </div>
-            <div>
+            <div className="max-h-[300px]">
                 <StockChart />
             </div>
             <div></div>

--- a/front/src/components/StockDetail.jsx
+++ b/front/src/components/StockDetail.jsx
@@ -1,17 +1,22 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import StockButton from "./StockButton";
 import { IoTriangleSharp } from "react-icons/io5";
 import { GetStockChart } from "../lib/apis/stock";
+import StockChart from "./StockChart";
 
 export default function StockDetail({ stock }) {
     const { id, name, price, diff } = stock;
+    // const [prices, setPrices] = useState(null);
 
-    useEffect(() => {
-        GetStockChart(id, 2).then((data) => console.log(data));
-    }, []);
+    // useEffect(() => {
+    //     GetStockChart(id, 1).then((data) => {
+    //         const priceList = data.map((el) => el.price);
+    //         setPrices(priceList);
+    //     });
+    // }, []);
 
     return (
-        <div className="bg-white w-full h-full col-span-3 px-6 py-9 flex flex-col justify-between">
+        <div className="bg-white w-full h-full col-span-3 px-6 py-9 flex flex-col space-y-3">
             <div className="flex justify-between items-center">
                 <span>{name}</span>
                 <span className={diff > 0 ? "text-shinhan-red" : "text-shinhan-blue"}>{price.toLocaleString()}</span>
@@ -25,10 +30,12 @@ export default function StockDetail({ stock }) {
                 </div>
             </div>
             <div className="flex">
-                <div className="w-28 h-28 bg-black rounded-full"></div>
+                <div className="w-20 h-20 bg-black rounded-full"></div>
                 <p>여기 회사 설명할거임</p>
             </div>
-            <div className="h-[200px] bg-black text-white">여기 차트 자리</div>
+            <div>
+                <StockChart />
+            </div>
             <div></div>
         </div>
     );

--- a/front/src/components/StockDetail.jsx
+++ b/front/src/components/StockDetail.jsx
@@ -1,8 +1,14 @@
+import { useEffect } from "react";
 import StockButton from "./StockButton";
 import { IoTriangleSharp } from "react-icons/io5";
+import { GetStockChart } from "../lib/apis/stock";
 
 export default function StockDetail({ stock }) {
-    const { name, price, diff } = stock;
+    const { id, name, price, diff } = stock;
+
+    useEffect(() => {
+        GetStockChart(id, 2).then((data) => console.log(data));
+    }, []);
 
     return (
         <div className="bg-white w-full h-full col-span-3 px-6 py-9 flex flex-col justify-between">

--- a/front/src/components/StockDetail.jsx
+++ b/front/src/components/StockDetail.jsx
@@ -1,14 +1,18 @@
 import StockButton from "./StockButton";
+import { IoTriangleSharp } from "react-icons/io5";
 
-export default function StockDetail(props) {
-    const title = props.title;
+export default function StockDetail({ stock }) {
+    const { name, price, diff } = stock;
 
     return (
         <div className="bg-white w-full h-full col-span-3 px-6 py-9 flex flex-col justify-between">
             <div className="flex justify-between items-center">
-                <span>{title}</span>
-                <span>가격</span>
-                <span>여기 상승하락</span>
+                <span>{name}</span>
+                <span className={diff > 0 ? "text-shinhan-red" : "text-shinhan-blue"}>{price.toLocaleString()}</span>
+                <div className={`flex items-center ml-2 ${diff > 0 ? "text-shinhan-red" : "text-shinhan-blue"}`}>
+                    <IoTriangleSharp className={diff <= 0 && "rotate-180"} />
+                    <span className="min-w-[34px] text-right">{Math.abs(diff).toLocaleString()}</span>
+                </div>
                 <div className="flex space-x-6">
                     <StockButton purpo="buy" onClick={() => {}} />
                     <StockButton purpo="sell" onClick={() => {}} />

--- a/front/src/lib/apis/stock.jsx
+++ b/front/src/lib/apis/stock.jsx
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const BASE_URL = "/api/market";
+const service = axios.create({ withCredentials: true, baseURL: BASE_URL });
+
+export async function GetStockList(turn) {
+    const res = await service.get(`/${turn}`);
+    return res.data;
+}

--- a/front/src/lib/apis/stock.jsx
+++ b/front/src/lib/apis/stock.jsx
@@ -12,3 +12,8 @@ export async function GetStockChart(stockId, turn) {
     const res = await service.get(`${stockId}/${turn}`);
     return res.data;
 }
+
+export async function GetRanking(userId) {
+    const res = await service.get(`rank/${userId}`);
+    return res.data;
+}

--- a/front/src/lib/apis/stock.jsx
+++ b/front/src/lib/apis/stock.jsx
@@ -7,3 +7,8 @@ export async function GetStockList(turn) {
     const res = await service.get(`/${turn}`);
     return res.data;
 }
+
+export async function GetStockChart(stockId, turn) {
+    const res = await service.get(`${stockId}/${turn}`);
+    return res.data;
+}

--- a/front/src/routes/main/Market.jsx
+++ b/front/src/routes/main/Market.jsx
@@ -1,68 +1,19 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Navbar from "../../components/Navbar";
 import StockCard from "../../components/StockCard";
 import StockDetail from "../../components/StockDetail";
 import Ranking from "../../components/Ranking/Ranking";
+import { GetStockList } from "../../lib/apis/stock";
 
 const Market = () => {
-    const stockList = [
-        {
-            title: "미미전자",
-            price: 3000,
-            change: "up",
-            value: 1000,
-        },
-        {
-            title: "미미자동차",
-            price: 33000,
-            change: "down",
-            value: 300,
-        },
-        {
-            title: "미미화장품",
-            price: 3000,
-            change: "down",
-            value: 300,
-        },
-        {
-            title: "미미엔터",
-            price: 3000,
-            change: "up",
-            value: 50,
-        },
-        {
-            title: "미미IT",
-            price: 3000,
-            change: "down",
-            value: 300,
-        },
-        {
-            title: "미미건설",
-            price: 3000,
-            change: "down",
-            value: 300,
-        },
-        {
-            title: "미미제약",
-            price: 3000,
-            change: "down",
-            value: 300,
-        },
-        {
-            title: "미미호텔",
-            price: 13000,
-            change: "up",
-            value: 8,
-        },
-        {
-            title: "미미화학",
-            price: 3000,
-            change: "down",
-            value: 300,
-        },
-    ];
-
+    const [stockList, setStockList] = useState([]);
     const [selected, setSelected] = useState("");
+
+    useEffect(() => {
+        GetStockList(1)
+            .then((data) => setStockList(data))
+            .catch((err) => console.log(err.response));
+    }, []);
 
     return (
         <div className="bg-background-pattern bg-cover bg-center h-screen">
@@ -71,7 +22,7 @@ const Market = () => {
                 <div className="bg-back-yellow col-span-3 h-full grid grid-cols-4 p-6 gap-6">
                     <div className="col-span-1 grid grid-rows-9 gap-1">
                         {stockList.map((el, i) => (
-                            <StockCard stock={el} key={i} selected={selected} onClick={() => setSelected(el.title)} />
+                            <StockCard stock={el} key={i} selected={selected} onClick={() => setSelected(el.name)} />
                         ))}
                     </div>
                     {selected && <StockDetail title={selected} />}

--- a/front/src/routes/main/Market.jsx
+++ b/front/src/routes/main/Market.jsx
@@ -7,7 +7,7 @@ import { GetStockList } from "../../lib/apis/stock";
 
 const Market = () => {
     const [stockList, setStockList] = useState([]);
-    const [selected, setSelected] = useState("");
+    const [selected, setSelected] = useState(null);
 
     useEffect(() => {
         GetStockList(1)
@@ -22,10 +22,17 @@ const Market = () => {
                 <div className="bg-back-yellow col-span-3 h-full grid grid-cols-4 p-6 gap-6">
                     <div className="col-span-1 grid grid-rows-9 gap-1">
                         {stockList.map((el, i) => (
-                            <StockCard stock={el} key={i} selected={selected} onClick={() => setSelected(el.name)} />
+                            <StockCard
+                                stock={el}
+                                key={i}
+                                selected={selected?.name}
+                                onClick={() => {
+                                    setSelected(el);
+                                }}
+                            />
                         ))}
                     </div>
-                    {selected && <StockDetail title={selected} />}
+                    {selected && <StockDetail stock={selected} />}
                 </div>
                 <div className="grid grid-rows-3 h-full">
                     <div className="bg-back-yellow mb-4">여기 프로필 부분</div>

--- a/front/src/routes/main/Market.jsx
+++ b/front/src/routes/main/Market.jsx
@@ -3,11 +3,24 @@ import Navbar from "../../components/Navbar";
 import StockCard from "../../components/StockCard";
 import StockDetail from "../../components/StockDetail";
 import Ranking from "../../components/Ranking/Ranking";
-import { GetStockList } from "../../lib/apis/stock";
+import { GetStockChart, GetStockList } from "../../lib/apis/stock";
+import { useDispatch } from "react-redux";
+import { savePrices } from "../../store/stockSlice";
 
 const Market = () => {
     const [stockList, setStockList] = useState([]);
     const [selected, setSelected] = useState(null);
+    const dispatch = useDispatch();
+    const saveStock = (el) => {
+        setSelected(el);
+        GetStockChart(el.id, 1)
+            .then((data) => {
+                const prices = data.map((el) => el.price);
+                // console.log(prices);
+                dispatch(savePrices(prices));
+            })
+            .catch((err) => console.log(err));
+    };
 
     useEffect(() => {
         GetStockList(1)
@@ -27,7 +40,7 @@ const Market = () => {
                                 key={i}
                                 selected={selected?.name}
                                 onClick={() => {
-                                    setSelected(el);
+                                    saveStock(el);
                                 }}
                             />
                         ))}

--- a/front/src/store/stockSlice.jsx
+++ b/front/src/store/stockSlice.jsx
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    prices: [],
+};
+
+const stockSlice = createSlice({
+    name: "stockSlice",
+    initialState,
+    reducers: {
+        reset: () => {
+            return initialState;
+        },
+        savePrices: (state, action) => {
+            const newPrices = action.payload;
+            console.log(newPrices);
+            state.prices = newPrices;
+        },
+    },
+});
+
+export default stockSlice.reducer;
+export const { reset, savePrices } = stockSlice.actions;

--- a/front/src/store/store.jsx
+++ b/front/src/store/store.jsx
@@ -1,0 +1,17 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { combineReducers } from "redux";
+import stockSlice from "./stockSlice";
+
+export const rootReducer = combineReducers({
+    stock: stockSlice,
+});
+
+const store = configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({
+            serializableCheck: false,
+        }),
+});
+
+export default store;

--- a/front/vite.config.js
+++ b/front/vite.config.js
@@ -4,6 +4,14 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
+    server: {
+        proxy: {
+            "/api": {
+                target: "http://127.0.0.1:3000",
+                // changeOrigin: true,
+            },
+        },
+    },
     resolve: {
         alias: [
             // 절대경로로 접근하기


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) dev/feat/fe/market/stockAPI -> dev/feat/fe/market/layout

### 변경 사항
- stockList 9개 불러오는 API 추가(추후에 turn 변경해줘야함)
- 주식 디테일 안에 차트와 연결
- 랭킹 불러오는 API 추가(아직 더미 데이터를 남겨두었지만 나중에 지워줘야 함)

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/122499274/4647fc17-ea71-41f9-b52c-ec6250cda6e8)
![image](https://github.com/PDA-4-1/StockForest/assets/122499274/d5d078e8-bb5d-4e48-9a07-7271432284da)

