### PR TITLE
[FEAT] 한국투자증권 open API 연동을 통한 퀴즈 정답 처리 구현

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
             "name": "server",
             "version": "0.0.0",
             "dependencies": {
+                "axios": "^1.7.2",
                 "bcrypt": "^5.1.1",
                 "cookie-parser": "~1.4.4",
                 "cors": "^2.8.5",
@@ -133,6 +134,21 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/axios": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -266,6 +282,17 @@
                 "color-support": "bin.js"
             }
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -335,6 +362,14 @@
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dependencies": {
                 "ms": "2.0.0"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/delegates": {
@@ -503,6 +538,38 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -1254,6 +1321,11 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
                 "http-errors": "~1.6.3",
                 "jsonwebtoken": "^9.0.2",
                 "moment": "^2.30.1",
+                "moment-timezone": "^0.5.45",
                 "morgan": "~1.9.1",
                 "mysql2": "^3.10.0",
                 "nodemon": "^3.1.3"
@@ -1057,6 +1058,17 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
             "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/moment-timezone": {
+            "version": "0.5.45",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+            "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+            "dependencies": {
+                "moment": "^2.29.4"
+            },
             "engines": {
                 "node": "*"
             }

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
         "dev": "nodemon ./bin/www"
     },
     "dependencies": {
+        "axios": "^1.7.2",
         "bcrypt": "^5.1.1",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
         "http-errors": "~1.6.3",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.30.1",
+        "moment-timezone": "^0.5.45",
         "morgan": "~1.9.1",
         "mysql2": "^3.10.0",
         "nodemon": "^3.1.3"

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -18,7 +18,7 @@ router.use("/users", usersRouter);
 
 router.use("/farm", loginRequired, farmRouter);
 router.use("/market", loginRequired, marketRouter);
-router.use("/quiz", quizRouter);
+router.use("/quiz", loginRequired, quizRouter);
 router.use("/ranking", loginRequired, rankingRouter);
 
 module.exports = router;

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -18,7 +18,7 @@ router.use("/users", usersRouter);
 
 router.use("/farm", loginRequired, farmRouter);
 router.use("/market", loginRequired, marketRouter);
-router.use("/quiz", loginRequired, quizRouter);
+router.use("/quiz", quizRouter);
 router.use("/ranking", loginRequired, rankingRouter);
 
 module.exports = router;

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -49,6 +49,30 @@ router.patch("/answer", async (req, res) => {
 
     //사용자가 응답한 기록 불러오기
 
+    // 한국투자증권 API 연결 - 일일 주가 요청하기
+    const KIS_URL =
+        "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
+    headers = {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+        appkey: process.env.appKey,
+        appsecret: process.env.appSecret,
+        tr_id: process.env.tr_id,
+    };
+    const params = {
+        FID_COND_MRKT_DIV_CODE: "J",
+        FID_INPUT_ISCD: "005930",
+        FID_INPUT_DATE_1: "20240619",
+        FID_INPUT_DATE_2: "20240620",
+        FID_PERIOD_DIV_CODE: "D",
+        FID_ORG_ADJ_PRC: 0,
+    };
+
+    try {
+        const stockReq = await axios.get(KIS_URL, { headers, params });
+        console.log(stockReq.data);
+    } catch (e) {
+        console.log(e);
     }
 
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -111,7 +111,8 @@ router.patch("/answer", async (req, res) => {
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것
     try {
         let isUp, isCorrect;
-        if(todayCost==yesterdayCost) isCorrect = 0; // 가격 변동 없으면 오답처리
+        if (todayCost == yesterdayCost)
+            isCorrect = 0; // 가격 변동 없으면 오답처리
         else {
             isUp = todayCost > yesterdayCost ? 1 : 0;
             isCorrect = userResponse[0].up_down == isUp ? 1 : 0; // 정답 여부
@@ -120,19 +121,18 @@ router.patch("/answer", async (req, res) => {
         await pool.query(answerQuery, [isCorrect, 10, yesterday]); //userId req.userId
 
         // 맞았을 경우 사용자의 pdi 추가
-        const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
+        if (isCorrect) {
+            const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
+            await pool.query(addPointQuery, [10]); // userId req.userId
+        }
 
         res.send({
-            // stock_name:
+            stockCode: stockCode,
+            answerCheck: isUp,
             isCorrect: isCorrect,
         });
     } catch (e) {
         console.log(e);
-    }
-
-    let result2;
-    if (isCorrect) {
-        [result2] = await pool.query(addPointQuery, [userId]);
     }
 });
 

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -109,23 +109,31 @@ router.patch("/answer", async (req, res) => {
     }
 
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것
-    // const userId = req.body.userId;
-    // const date = req.body.date;
-    // const isCorrect = req.body.isCorrect;
+    try {
+        let isUp, isCorrect;
+        if(todayCost==yesterdayCost) isCorrect = 0; // 가격 변동 없으면 오답처리
+        else {
+            isUp = todayCost > yesterdayCost ? 1 : 0;
+            isCorrect = userResponse[0].up_down == isUp ? 1 : 0; // 정답 여부
+        }
+        const answerQuery = `UPDATE quiz SET is_correct = ? WHERE user_id = ? AND date = ?`;
+        await pool.query(answerQuery, [isCorrect, 10, yesterday]); //userId req.userId
 
-    // const answerQuery = `UPDATE quiz SET is_correct = ? WHERE user_id = ? AND date = ?`;
-    // const [result] = await pool.query(answerQuery, [isCorrect, userId, date]);
+        // 맞았을 경우 사용자의 pdi 추가
+        const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
 
-    // // 맞았을 경우 사용자의 pdi 추가
-    // const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
-    // let result2;
-    // if (isCorrect) {
-    //     [result2] = await pool.query(addPointQuery, [userId]);
-    // }
-    // res.send({
-    //     success: result.affectedRows,
-    //     isCorrect: result2.affectedRows,
-    // });
+        res.send({
+            // stock_name:
+            isCorrect: isCorrect,
+        });
+    } catch (e) {
+        console.log(e);
+    }
+
+    let result2;
+    if (isCorrect) {
+        [result2] = await pool.query(addPointQuery, [userId]);
+    }
 });
 
 module.exports = router;

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -49,10 +49,11 @@ router.patch("/answer", async (req, res) => {
     const accessToken = tokenReq.data.access_token;
 
     //사용자가 응답한 기록 불러오기
-    const currentDate = moment().tz("Asia/Seoul").format("YYYY-MM-DD");//오늘 날짜
+    const currentDate = moment().tz("Asia/Seoul").subtract(1, "days").format("YYYY-MM-DD");//오늘 날짜
     console.log(currentDate);
     getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
     const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
+    if(userResponse.length==0) throw new Error("어제의 퀴즈 기록이 없습니다")
     console.log(userResponse[0]);
 
     // 한국투자증권 API 연결 - 일일 주가 요청하기

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -48,14 +48,6 @@ router.patch("/answer", async (req, res) => {
     // Token 확인
     const accessToken = tokenReq.data.access_token;
 
-    //사용자가 응답한 기록 불러오기
-    const currentDate = moment().tz("Asia/Seoul").subtract(1, "days").format("YYYY-MM-DD");//오늘 날짜
-    console.log(currentDate);
-    getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
-    const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
-    if(userResponse.length==0) throw new Error("어제의 퀴즈 기록이 없습니다")
-    console.log(userResponse[0]);
-
     // 한국투자증권 API 연결 - 일일 주가 요청하기
     const KIS_URL =
         "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
@@ -85,6 +77,18 @@ router.patch("/answer", async (req, res) => {
     } catch (e) {
         console.log(e);
     }
+    
+    //사용자가 응답한 기록 불러오기
+    const currentDate = moment()
+        .tz("Asia/Seoul")
+        .subtract(1, "days")
+        .format("YYYY-MM-DD"); //오늘 날짜
+    console.log(currentDate);
+    getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
+    const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
+    if (userResponse.length == 0)
+        throw new Error("어제의 퀴즈 기록이 없습니다");
+    console.log(userResponse[0]);
 
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것
     // const userId = req.body.userId;

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -2,6 +2,7 @@ var express = require("express");
 var pool = require("../../config/db.connect.js");
 const axios = require("axios");
 const dotenv = require("dotenv");
+const moment = require("moment-timezone");
 var router = express.Router();
 
 dotenv.config();
@@ -48,6 +49,11 @@ router.patch("/answer", async (req, res) => {
     const accessToken = tokenReq.data.access_token;
 
     //사용자가 응답한 기록 불러오기
+    const currentDate = moment().tz("Asia/Seoul").format("YYYY-MM-DD");//오늘 날짜
+    console.log(currentDate);
+    getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
+    const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
+    console.log(userResponse[0]);
 
     // 한국투자증권 API 연결 - 일일 주가 요청하기
     const KIS_URL =
@@ -68,9 +74,13 @@ router.patch("/answer", async (req, res) => {
         FID_ORG_ADJ_PRC: 0,
     };
 
+    let todayCost, yesterdayCost;
     try {
         const stockReq = await axios.get(KIS_URL, { headers, params });
-        console.log(stockReq.data);
+        todayCost = stockReq.data.output2[0].stck_clpr;
+        yesterdayCost = stockReq.data.output2[1].stck_clpr;
+        console.log(todayCost);
+        console.log(yesterdayCost);
     } catch (e) {
         console.log(e);
     }

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -67,7 +67,7 @@ router.patch("/answer", async (req, res) => {
         .format("YYYY-MM-DD"); // 하루 전 날
     console.log(yesterday);
     getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
-    const [userResponse] = await pool.query(getResponseSQL, [1, yesterday]);
+    const [userResponse] = await pool.query(getResponseSQL, [req.userId, yesterday]);
     if (userResponse.length == 0)
         throw new Error("어제의 퀴즈 기록이 없습니다");
     console.log(userResponse[0]);
@@ -118,18 +118,18 @@ router.patch("/answer", async (req, res) => {
             isCorrect = userResponse[0].up_down == isUp ? 1 : 0; // 정답 여부
         }
         const answerQuery = `UPDATE quiz SET is_correct = ? WHERE user_id = ? AND date = ?`;
-        await pool.query(answerQuery, [isCorrect, 10, yesterday]); //userId req.userId
+        await pool.query(answerQuery, [isCorrect, req.userId, yesterday]);
 
         // 맞았을 경우 사용자의 pdi 추가
         if (isCorrect) {
             const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
-            await pool.query(addPointQuery, [10]); // userId req.userId
+            await pool.query(addPointQuery, [req.userId]);
         }
 
         res.send({
-            stockCode: stockCode,
-            answerCheck: isUp,
-            isCorrect: isCorrect,
+            stockCode: stockCode, // 고른 종목
+            answerCheck: isUp, //가격이 올랐나?
+            isCorrect: isCorrect, // 사용자가 맞았나?
         });
     } catch (e) {
         console.log(e);

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -48,6 +48,18 @@ router.patch("/answer", async (req, res) => {
     // Token 확인
     const accessToken = tokenReq.data.access_token;
 
+    //사용자가 응답한 기록 불러오기
+    const currentDate = moment()
+        .tz("Asia/Seoul")
+        .subtract(1, "days")
+        .format("YYYY-MM-DD"); //오늘 날짜
+    console.log(currentDate);
+    getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
+    const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
+    if (userResponse.length == 0)
+        throw new Error("어제의 퀴즈 기록이 없습니다");
+    console.log(userResponse[0]);
+    
     // 한국투자증권 API 연결 - 일일 주가 요청하기
     const KIS_URL =
         "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
@@ -78,17 +90,6 @@ router.patch("/answer", async (req, res) => {
         console.log(e);
     }
     
-    //사용자가 응답한 기록 불러오기
-    const currentDate = moment()
-        .tz("Asia/Seoul")
-        .subtract(1, "days")
-        .format("YYYY-MM-DD"); //오늘 날짜
-    console.log(currentDate);
-    getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
-    const [userResponse] = await pool.query(getResponseSQL, [1, currentDate]);
-    if (userResponse.length == 0)
-        throw new Error("어제의 퀴즈 기록이 없습니다");
-    console.log(userResponse[0]);
 
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것
     // const userId = req.body.userId;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/feat/openAPI -> develop

### 변경 사항
한국투자증권 openAPI 요청을 통해 토큰을 생성하고 국내주식기간별시세를 조회하는 로직을 구현했습니다.
조회된 종가를 통해 사용자가 퀴즈에 입력한 답과 실제 주가의 등락을 비교하여 퀴즈의 정답여부를 판별하는 기능을 구현하였습니다.

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/a6808202-5f39-4229-897b-07c181f1c0a9)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/52cd4765-13c1-44f5-8700-61e3f2da0a69)

close #49