### PR TITLE
[FEAT] 신한투자증권 open API 연동 및 node schedule 활용을 통한 퀴즈 정답 확인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "node-schedule": "^2.1.1"
       }
     },
     "node_modules/accepts": {
@@ -109,6 +110,17 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -390,6 +402,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -452,6 +477,19 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-schedule": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "dependencies": {
+        "cron-parser": "^4.2.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/object-inspect": {
@@ -637,6 +675,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "node-schedule": "^2.1.1"
   }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -6,7 +6,7 @@ var cookieParser = require("cookie-parser");
 var logger = require("morgan");
 
 var apiRouter = require("./routes/api/index");
-var doJob = require("./utils/schedule");
+var {doJob, doKIS} = require("./utils/schedule");
 
 var app = express();
 const cors = require("cors");
@@ -19,6 +19,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
 doJob();
+doKIS();
 app.use("/api", apiRouter);
 
 // catch 404 and forward to error handler

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ var cookieParser = require("cookie-parser");
 var logger = require("morgan");
 
 var apiRouter = require("./routes/api/index");
+var doJob = require("./utils/schedule");
 
 var app = express();
 const cors = require("cors");
@@ -17,6 +18,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
+doJob();
 app.use("/api", apiRouter);
 
 // catch 404 and forward to error handler

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -7,18 +7,6 @@ var router = express.Router();
 
 dotenv.config();
 
-const realCode = [
-    "005930",
-    "035720",
-    "041510", //삼성전자 카카오 SM
-    "005380",
-    "068270",
-    "006360", //현대차 셀트리온 GS건설
-    "090430",
-    "008770",
-    "051910",
-]; //아모레퍼시픽 신라호텔 LG화학
-
 router.post("/response", async (req, res) => {
     //TODO : 사용자가 퀴즈에 답한 내용을 기록. 어떤 종목인지, 오를지 내릴지
     try {
@@ -43,22 +31,6 @@ router.post("/response", async (req, res) => {
 });
 
 router.patch("/answer", async (req, res) => {
-    // 한국투자증권 API 연결 - OAuth2 토큰 받기
-    // 요청 내용 작성, 요청 보내기
-    let headers;
-    const URL = "https://openapi.koreainvestment.com:9443/oauth2/tokenP";
-    headers = {
-        "content-type": "application/json",
-    };
-    const body = {
-        grant_type: "client_credentials",
-        appkey: process.env.appKey,
-        appsecret: process.env.appSecret,
-    };
-    const tokenReq = await axios.post(URL, body, { headers });
-
-    // Token 확인
-    const accessToken = tokenReq.data.access_token;
 
     // 사용자가 응답한 기록 불러오기
     const yesterday = moment()
@@ -75,41 +47,6 @@ router.patch("/answer", async (req, res) => {
         throw new Error("어제의 퀴즈 기록이 없습니다");
     console.log(userResponse[0]);
 
-    // 한국투자증권 API 연결 - 일일 주가 요청하기
-    const stockCode = realCode[userResponse[0].stock_id - 1];
-    const startDate = moment(yesterday).format("YYYYMMDD");
-    const endDate = moment(yesterday).add(1, "days").format("YYYYMMDD");
-    console.log("stockCode: " + stockCode);
-    console.log("startDate: " + startDate);
-    console.log("endDate: " + endDate);
-    const KIS_URL =
-        "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
-    headers = {
-        "content-type": "application/json",
-        authorization: `Bearer ${accessToken}`,
-        appkey: process.env.appKey,
-        appsecret: process.env.appSecret,
-        tr_id: process.env.tr_id,
-    };
-    const params = {
-        FID_COND_MRKT_DIV_CODE: "J",
-        FID_INPUT_ISCD: stockCode,
-        FID_INPUT_DATE_1: startDate,
-        FID_INPUT_DATE_2: endDate,
-        FID_PERIOD_DIV_CODE: "D",
-        FID_ORG_ADJ_PRC: 0,
-    };
-
-    let todayCost, yesterdayCost;
-    try {
-        const stockReq = await axios.get(KIS_URL, { headers, params });
-        todayCost = stockReq.data.output2[0].stck_clpr;
-        yesterdayCost = stockReq.data.output2[1].stck_clpr;
-        console.log(todayCost);
-        console.log(yesterdayCost);
-    } catch (e) {
-        console.log(e);
-    }
 
     // //TODO : 퀴즈 답 확인, 맞았을 경우 보상받은 포인트까지 계산할 것
     try {

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -139,4 +139,18 @@ router.patch("/answer", async (req, res) => {
     }
 });
 
+router.get("/content", async (req, res) => {
+    //TODO : 퀴즈에 띄울 투자전략 내용 반환하기
+    try {
+        const resQuery = `SELECT content FROM quiz_news WHERE date = ?`;
+        const currentDate = moment().tz("Asia/Seoul").format("YYYY-MM-DD");
+        const [result] = await pool.query(resQuery, [currentDate]);
+        console.log(result[0].content);
+        res.send({ content: result[0].content });
+    } catch (err) {
+        console.log(err);
+        res.send(err);
+    }
+});
+
 module.exports = router;

--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -67,7 +67,10 @@ router.patch("/answer", async (req, res) => {
         .format("YYYY-MM-DD"); // 하루 전 날
     console.log(yesterday);
     getResponseSQL = `SELECT stock_id, up_down FROM quiz WHERE user_id = ? AND date = ?`;
-    const [userResponse] = await pool.query(getResponseSQL, [req.userId, yesterday]);
+    const [userResponse] = await pool.query(getResponseSQL, [
+        req.userId,
+        yesterday,
+    ]);
     if (userResponse.length == 0)
         throw new Error("어제의 퀴즈 기록이 없습니다");
     console.log(userResponse[0]);

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -120,7 +120,7 @@ const doKIS = async () => {
             }
         }
     };
-    await executeJob();
+    // await executeJob();
     schedule.scheduleJob("0 0 17 * * *", executeJob);
 }
 

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -24,6 +24,18 @@ const doJob = async () => {
         const res = await axios(config);
         const data = res.data.dataBody.list
         // console.log(data);
+        let todayData;
+        if(data[1].reg_date===date && data[1].content.length>=300) {
+            todayData = data[1].content;
+        }
+        else if(data[0].reg_date===date && data[0].content.length>=300) {
+            todayData = data[0].content;
+        }
+        else todayData = data[4].content;
+        // console.log(todayData.length);
+
+        const query = `INSERT INTO quiz_news (date, content) VALUES (?,?)`;
+        await pool.query(query, [date, todayData]);
     };
     await executeJob();
     schedule.scheduleJob("*/30 * * * * *", executeJob);

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -12,33 +12,116 @@ const date = moment().format("YYYY.MM.DD");
 
 const doJob = async () => {
     const executeJob = async () => {
-        var config = {
+        const config = {
             method: "get",
             maxBodyLength: Infinity,
             url: "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/invest",
             headers: {
                 apiKey: "l7xxR7Fe0dP3i8KPZaPKpknI2vWrMeJfwDpk",
             },
-            httpsAgent: agent
+            httpsAgent: agent,
         };
         const res = await axios(config);
-        const data = res.data.dataBody.list
+        const data = res.data.dataBody.list;
         // console.log(data);
         let todayData;
-        if(data[1].reg_date===date && data[1].content.length>=300) {
+        if (data[1].reg_date === date && data[1].content.length >= 300) {
             todayData = data[1].content;
-        }
-        else if(data[0].reg_date===date && data[0].content.length>=300) {
+        } else if (data[0].reg_date === date && data[0].content.length >= 300) {
             todayData = data[0].content;
-        }
-        else todayData = data[4].content;
+        } else todayData = data[4].content;
         // console.log(todayData.length);
 
         const query = `INSERT INTO quiz_news (date, content) VALUES (?,?)`;
         await pool.query(query, [date, todayData]);
     };
-    await executeJob();
+    // await executeJob();
     schedule.scheduleJob("0 0 8 * * *", executeJob);
 };
 
-module.exports = doJob;
+const realCode = [
+    "005930",
+    "035720",
+    "041510", //삼성전자 카카오 SM
+    "005380",
+    "068270",
+    "006360", //현대차 셀트리온 GS건설
+    "090430",
+    "008770",
+    "051910",
+]; //아모레퍼시픽 신라호텔 LG화학
+
+const doKIS = async () => {
+    const executeJob = async () => {
+        // 한국투자증권 API 연결 - OAuth2 토큰 받기
+        // 요청 내용 작성, 요청 보내기
+        let headers;
+        const URL = "https://openapi.koreainvestment.com:9443/oauth2/tokenP";
+        headers = {
+            "content-type": "application/json",
+        };
+        const body = {
+            grant_type: "client_credentials",
+            appkey: process.env.appKey,
+            appsecret: process.env.appSecret,
+        };
+        const tokenReq = await axios.post(URL, body, { headers });
+
+        // Token 확인
+        const accessToken = tokenReq.data.access_token;
+
+        // 한국투자증권 API 연결 - 일일 주가 요청하기
+        const yesterday = moment()
+            .tz("Asia/Seoul")
+            .subtract(1, "days")
+            .format("YYYY-MM-DD"); // 하루 전 날
+        const today = moment(yesterday).add(1, "days").format("YYYY-MM-DD");
+        console.log("today: " + today);
+        const startDate = moment(yesterday).format("YYYYMMDD");
+        const endDate = moment(yesterday).add(1, "days").format("YYYYMMDD");
+
+        const KIS_URL =
+            "https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
+        headers = {
+            "content-type": "application/json",
+            authorization: `Bearer ${accessToken}`,
+            appkey: process.env.appKey,
+            appsecret: process.env.appSecret,
+            tr_id: process.env.tr_id,
+        };
+
+        for (let i = 0; i < realCode.length; i++) {
+            const params = {
+                FID_COND_MRKT_DIV_CODE: "J",
+                FID_INPUT_ISCD: realCode[i],
+                FID_INPUT_DATE_1: startDate,
+                FID_INPUT_DATE_2: endDate,
+                FID_PERIOD_DIV_CODE: "D",
+                FID_ORG_ADJ_PRC: 0,
+            };
+            let todayCost, yesterdayCost;
+            try {
+                const stockReq = await axios.get(KIS_URL, { headers, params });
+                todayCost = stockReq.data.output2[0].stck_clpr;
+                yesterdayCost = stockReq.data.output2[1].stck_clpr;
+                console.log(todayCost);
+                console.log(yesterdayCost);
+                const isUp =
+                    todayCost > yesterdayCost
+                        ? 1
+                        : todayCost < yesterdayCost
+                        ? 0
+                        : 3;
+                const query = `INSERT INTO quiz_answer (date, stock_id, answer) VALUES (?,?,?)`;
+                const [res] = await pool.query(query, [today, i + 1, isUp]);
+                console.log(res.insertId);
+            } catch (e) {
+                console.log(e);
+            }
+        }
+    };
+    await executeJob();
+    schedule.scheduleJob("0 0 17 * * *", executeJob);
+}
+
+module.exports = {doJob, doKIS};

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -38,7 +38,7 @@ const doJob = async () => {
         await pool.query(query, [date, todayData]);
     };
     await executeJob();
-    schedule.scheduleJob("*/30 * * * * *", executeJob);
+    schedule.scheduleJob("0 0 8 * * *", executeJob);
 };
 
 module.exports = doJob;

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -1,0 +1,32 @@
+const schedule = require("node-schedule");
+const axios = require("axios");
+const https = require("https");
+const moment = require("moment");
+const pool = require("../config/db.connect");
+
+const agent = new https.Agent({
+    rejectUnauthorized: false,
+});
+
+const date = moment().format("YYYY.MM.DD");
+
+const doJob = async () => {
+    const executeJob = async () => {
+        var config = {
+            method: "get",
+            maxBodyLength: Infinity,
+            url: "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/invest",
+            headers: {
+                apiKey: "l7xxR7Fe0dP3i8KPZaPKpknI2vWrMeJfwDpk",
+            },
+            httpsAgent: agent
+        };
+        const res = await axios(config);
+        const data = res.data.dataBody.list
+        // console.log(data);
+    };
+    await executeJob();
+    schedule.scheduleJob("*/30 * * * * *", executeJob);
+};
+
+module.exports = doJob;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/feat/openAPI -> develop

### 변경 사항
신한투자증권 투자전략 API 요청하여 DB에 저장하는 기능 추가 -> 퀴즈 참고 자료로 사용자에게 보여줄 예정
클라이언트에서 서버에 투자전략 자료 요청하는 API 구현
node schedule 이용, 특정 시간마다 함수 돌아가도록 수정

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/cb98cd8d-69cc-4de8-b710-f92ead90b979)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/185eb90a-853b-4040-bd52-deecc25fd6fe)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/ea3baa2a-79e2-40c9-85a5-d0af45216ea3)

close #54