### PR TITLE
[FIX] 판매 요청 2번 보낼때 터지는 현상 수정

### DIFF
--- a/server/routes/api/market.js
+++ b/server/routes/api/market.js
@@ -146,6 +146,7 @@ router.get("/sell/:stockId/:turn", async (req, res) => {
                     date.format("YYYY-MM-DD"),
                 ]);
                 res.status(200).send(result);
+                break;
             }
         }
     } catch (error) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> develop

### 변경 사항
- 판매를 위해 주식 정보를 요청할 때 status 요청이 2번 와서 터지는 현상 수정 

