### PR TITLE
[UPDATE] 퀴즈 답 확인 -> 주말 및 오후 4시 이전 확인 불가능하게 수정

### DIFF
--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -59,6 +59,17 @@ const doKIS = async () => {
             console.log("주말입니다 !");
             return;
         }
+        //오후 4시 확인
+        const startOfDay = moment.tz("Asia/Seoul").startOf("day"); // 오늘의 시작 시간 (00:00:00)
+        const endOfQuizTime = moment
+            .tz("Asia/Seoul")
+            .startOf("day")
+            .add(16, "hours"); // 오늘의 오후 4시 (16:00:00)
+        if (date.isBetween(startOfDay, endOfQuizTime)) {
+            console.log("오후 4시 이전에는 퀴즈의 답을 확인할 수 없습니다.");
+            console.log(date.format());
+            return;
+        }
         let headers;
         const URL = "https://openapi.koreainvestment.com:9443/oauth2/tokenP";
         headers = {

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -132,7 +132,7 @@ const doKIS = async () => {
             }
         }
     };
-    await executeJob();
+    // await executeJob();
     schedule.scheduleJob("0 0 17 * * *", executeJob);
 };
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/feat/openAPI -> develop

### 변경 사항
주식 장이 열리지 않는 주말 및 시장 마감 전(오후 4시로 설정)에는 퀴즈의 답을 확인할 수 없도록 수정했습니다.

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/e834c3a5-8cbf-490b-8b23-4d68c1cf877e)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/df9157d9-dd9d-479b-8cf1-488805b930ec)

close #62