### PR TITLE
[FIX] 주식수가 0개일때 랜더링 되지 않게 수정

### DIFF
--- a/front/src/components/Field.jsx
+++ b/front/src/components/Field.jsx
@@ -23,7 +23,7 @@ const Field = () => {
                 const getStock = await axios.get("/api/farm");
                 const stockdata = getStock.data;
                 const filteredStock = stockdata.filter(
-                    (stock) => stock.stock_id >= 1 && stock.stock_id <= 9
+                    (stock) => stock.stock_id >= 1 && stock.stock_id <= 9 && stock.quantity > 0
                 );
                 setUserStock(filteredStock);
             } catch (error) {
@@ -178,7 +178,7 @@ const Field = () => {
                 <div className="grid grid-rows-3 h-full">
                     <div className="row-span-1 ">
                         <FarmProfile />
-                    </div>
+                    </div>  
                     <div className="row-span-2 relative flex items-center justify-center">
                         {!isVisible && (
                             <img


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/fe/farm -> develop

### 변경 사항
주식수가 0개일 때 농장에서 랜더링이 되지않게 코드 수정하였습니다.

### 테스트 결과

![image](https://github.com/PDA-4-1/StockForest/assets/101380919/afbb11fd-f456-48ae-b0c0-e7d3523790ee)
![image](https://github.com/PDA-4-1/StockForest/assets/101380919/7f369ec3-f3c5-4591-81d0-37212e0c7335)
![image](https://github.com/PDA-4-1/StockForest/assets/101380919/74f66d3b-62eb-450e-9a72-db8f0709cd2b)
![image](https://github.com/PDA-4-1/StockForest/assets/101380919/a0566f35-7800-46a6-a441-ad03f5e13be5)


위 테스트 결과와 같이 구매한 주식을 전부 팔았을 경우 다시 농장에 가보면 해당 식물이 없는 것을 확인 할 수 있습니다.
