### PR TITLE
[FEAT] 팔러가기 버튼 눌렀을 때 시장에서 해당 주식 상세정보 뜨는 기능 추가

### DIFF
--- a/front/src/components/CompanyProfile.jsx
+++ b/front/src/components/CompanyProfile.jsx
@@ -1,7 +1,10 @@
-import axios from "axios";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { MdCancel } from "react-icons/md";
+import { useDispatch, useSelector } from "react-redux";
+import axios from "axios";
+import { saveSelectedStock } from "../store/stockSlice";
+import { GetStockList } from "../lib/apis/stock";
 
 const CompanyProfile = ({
     visible,
@@ -12,9 +15,23 @@ const CompanyProfile = ({
     currentPrice,
 }) => {
     const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const turn = useSelector((state) => state.user.user.turn);
 
-    const goMarket = () => {
-        navigate("/market");
+    const goMarket = async () => {
+        try {
+            const stockList = await GetStockList(turn);
+
+            const marketData = stockList.find(
+                (item) => item.id === stock.stock_id
+            );
+
+            dispatch(saveSelectedStock(marketData));
+
+            navigate("/market");
+        } catch (error) {
+            console.error("Error fetching stock list:", error);
+        }
     };
 
     return (
@@ -36,10 +53,6 @@ const CompanyProfile = ({
                             </div>
                         )}
                         <div>{name}</div>
-                        {/* <button
-                            onClick={onClose}
-                            className="relative left-[10px] bg-wood-opacity-50 text-white px-2 py-2 rounded hover:brightness-75"
-                        ></button> */}
                         <MdCancel
                             onClick={onClose}
                             className="relative left-[10px] cursor-pointer"

--- a/front/src/routes/main/Market.jsx
+++ b/front/src/routes/main/Market.jsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import Navbar from "../../components/Navbar";
 import StockCard from "../../components/StockCard";
 import StockDetail from "../../components/StockDetail";
 import Ranking from "../../components/Ranking/Ranking";
 import { GetStockChart, GetStockList, NextTurn } from "../../lib/apis/stock";
-import { useDispatch, useSelector } from "react-redux";
-import { savePrices, saveStockList } from "../../store/stockSlice";
+import {
+    savePrices,
+    saveStockList,
+    saveSelectedStock,
+} from "../../store/stockSlice";
 import Profile from "../../components/Profile";
 import { GetUserProfile } from "../../lib/apis/user";
 import { saveTurn, saveUser } from "../../store/userSlice";
@@ -14,34 +18,35 @@ import NumModal from "../../components/Modal/NumModal";
 import pli from "~/public/imgs/pli.png";
 
 const Market = () => {
+    const selectedStock = useSelector((state) => state.stock.selectedStock);
     const stockList = useSelector((state) => state.stock.stockList);
-    const [selected, setSelected] = useState(null);
     const turn = useSelector((state) => state.user.user.turn);
+    const dispatch = useDispatch();
+
     const [modalSee, setModalSee] = useState(false);
     const [newsList, setNewsList] = useState([]);
     const [roundSee, setRoundSee] = useState(false);
     const [round, setRound] = useState(0);
-    const dispatch = useDispatch();
+
     const saveStock = (el) => {
-        if (selected == el) {
-            setSelected(null);
+        if (selectedStock?.id === el.id) {
+            dispatch(saveSelectedStock(null));
             return;
         }
-        setSelected(el);
+        dispatch(saveSelectedStock(el));
         GetStockChart(el.id, turn)
             .then((data) => {
                 const prices = data.map((el) => el.price);
-                // console.log(prices);
                 dispatch(savePrices(prices));
             })
             .catch((err) => console.log(err));
     };
+
     const nextTurn = () => {
         setRound(turn + 1);
         setRoundSee(true);
         NextTurn(turn)
             .then((data) => {
-                console.log(data);
                 setTimeout(() => {
                     setRoundSee(false);
                     if (data.news.length > 0) {
@@ -51,7 +56,7 @@ const Market = () => {
                     }
                 }, 1000);
                 dispatch(saveTurn());
-                setSelected(null);
+                dispatch(saveSelectedStock(null));
             })
             .catch((err) => console.log(err.response));
     };
@@ -59,17 +64,27 @@ const Market = () => {
     useEffect(() => {
         GetUserProfile()
             .then((data) => {
-                console.log(data);
                 dispatch(saveUser(data));
                 GetStockList(data.turn)
                     .then((data) => {
-                        console.log(data);
                         dispatch(saveStockList(data));
                     })
                     .catch((err) => console.log(err.response));
             })
             .catch((err) => console.log(err.response));
     }, [turn]);
+
+    useEffect(() => {
+        if (selectedStock) {
+            console.log(selectedStock);
+            GetStockChart(selectedStock.id, turn)
+                .then((data) => {
+                    const prices = data.map((el) => el.price);
+                    dispatch(savePrices(prices));
+                })
+                .catch((err) => console.log(err));
+        }
+    }, [selectedStock]);
 
     return (
         <div className="bg-background-pattern bg-cover bg-center h-screen">
@@ -81,15 +96,15 @@ const Market = () => {
                             <StockCard
                                 stock={el}
                                 key={i}
-                                selected={selected?.name}
+                                selected={selectedStock?.name}
                                 onClick={() => {
                                     saveStock(el);
                                 }}
                             />
                         ))}
                     </div>
-                    {selected ? (
-                        <StockDetail stock={selected} />
+                    {selectedStock ? (
+                        <StockDetail stock={selectedStock} />
                     ) : (
                         <div className="col-span-3 flex h-full justify-end items-end">
                             <img className="h-4/5" src={pli} alt="플리" />
@@ -101,9 +116,15 @@ const Market = () => {
                     <Ranking />
                 </div>
             </div>
-            {modalSee && <NewsModal onHide={() => setModalSee(false)} newsList={newsList} />}
+            {modalSee && (
+                <NewsModal
+                    onHide={() => setModalSee(false)}
+                    newsList={newsList}
+                />
+            )}
             {roundSee && <NumModal turn={round} />}
         </div>
     );
 };
+
 export default Market;

--- a/front/src/store/stockSlice.jsx
+++ b/front/src/store/stockSlice.jsx
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
     prices: [],
     stockList: [],
+    selectedStock: null,
     bgmOn: true,
 };
 
@@ -22,6 +23,10 @@ const stockSlice = createSlice({
             const newStockList = action.payload;
             state.stockList = newStockList;
         },
+        saveSelectedStock: (state, action) => {
+            const selectedStock = action.payload;
+            state.selectedStock = selectedStock;
+        },
         setBgm: (state, action) => {
             state.bgmOn = !state.bgmOn;
         },
@@ -29,4 +34,4 @@ const stockSlice = createSlice({
 });
 
 export default stockSlice.reducer;
-export const { reset, savePrices, saveStockList, setBgm } = stockSlice.actions;
+export const { reset, savePrices, saveSelectedStock, saveStockList, setBgm } = stockSlice.actions;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/fe/modify -> develop

### 변경 사항
농장에있는 회사 프로필에서 팔러가기를 눌렀을 때 해당 주식의 상세정보가 시장에서 바로 뜨게하는 기능을 추가하였습니다.

### 테스트 결과
아래는 테스트 결과입니다.

![image](https://github.com/PDA-4-1/StockForest/assets/101380919/c4402598-34c6-486f-9c4f-8144e3d3d3c4)
![image](https://github.com/PDA-4-1/StockForest/assets/101380919/b4e4c272-d457-4311-8cb2-72396ba45f98)

위 결과처럼 팔러가기 버튼을 누르면 해당 주식의 정보가 시장에서 바로 뜨는 것을 확인 할 수 있습니다.
