### PR TITLE
[FEAT] DB에 공휴일 저장, 공휴일인 경우의 실행 로직 추가

### DIFF
--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -59,10 +59,20 @@ const doKIS = async () => {
         if (dateDay === 0 || dateDay === 6) {
             //주말 확인
             console.log("주말입니다 !");
-            const weekendQuery = `INSERT INTO holiday VALUES (?, ?)`
+            const weekendQuery = `INSERT INTO holiday VALUES (?, ?)`;
             await pool.query(weekendQuery, [date.format("YYYY-MM-DD"), "주말"]);
             return;
         }
+        //공휴일 확인
+        const holyQuery = `SELECT COUNT(*) AS count, date_name FROM holiday WHERE date = ?;`;
+        const [isHoly] = await pool.query(holyQuery, [
+            date.format("YYYY-MM-DD"),
+        ]);
+        if (isHoly[0].count > 0) {
+            console.log("오늘은 공휴일입니다!");
+            return;
+        }
+
         //오후 4시 확인
         const startOfDay = moment.tz("Asia/Seoul").startOf("day"); // 오늘의 시작 시간 (00:00:00)
         const endOfQuizTime = moment

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -59,6 +59,8 @@ const doKIS = async () => {
         if (dateDay === 0 || dateDay === 6) {
             //주말 확인
             console.log("주말입니다 !");
+            const weekendQuery = `INSERT INTO holiday VALUES (?, ?)`
+            await pool.query(weekendQuery, [date.format("YYYY-MM-DD"), "주말"]);
             return;
         }
         //오후 4시 확인

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -55,9 +55,6 @@ const doKIS = async () => {
         // 한국투자증권 API 연결 - OAuth2 토큰 받기
         // 요청 내용 작성, 요청 보내기
         const date = moment().tz("Asia/Seoul");
-        // 로그 확인용
-        const current = moment().tz("Asia/Seoul").format("YYYY-MM-DD HH:mm:ss");
-        console.log("함수 실행 시각 : " + current);
         const dateDay = date.day();
         if (dateDay === 0 || dateDay === 6) {
             //주말 확인
@@ -70,12 +67,11 @@ const doKIS = async () => {
             .tz("Asia/Seoul")
             .startOf("day")
             .add(16, "hours"); // 오늘의 오후 4시 (16:00:00)
-        // 로그 확인용
-        // if (date.isBetween(startOfDay, endOfQuizTime)) {
-        //     console.log("오후 4시 이전에는 퀴즈의 답을 확인할 수 없습니다.");
-        //     console.log(date.format());
-        //     return;
-        // }
+        if (date.isBetween(startOfDay, endOfQuizTime)) {
+            console.log("오후 4시 이전에는 퀴즈의 답을 확인할 수 없습니다.");
+            console.log(date.format());
+            return;
+        }
         let headers;
         const URL = "https://openapi.koreainvestment.com:9443/oauth2/tokenP";
         headers = {
@@ -90,8 +86,6 @@ const doKIS = async () => {
 
         // Token 확인
         const accessToken = tokenReq.data.access_token;
-        // 로그 확인용
-        console.log("accessToken : " + accessToken);
 
         // 한국투자증권 API 연결 - 일일 주가 요청하기
         const yesterday = moment()
@@ -122,12 +116,8 @@ const doKIS = async () => {
                 FID_ORG_ADJ_PRC: 0,
             };
             let todayCost, yesterdayCost;
-            // 로그 확인용
-            console.log("params 할당 끝");
             try {
                 const stockReq = await axios.get(KIS_URL, { headers, params });
-                // 로그 확인용
-                console.log("api 요청 완료")
                 todayCost = stockReq.data.output2[0].stck_clpr;
                 yesterdayCost = stockReq.data.output2[1].stck_clpr;
                 const isUp =

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -35,7 +35,7 @@ const doJob = async () => {
         await pool.query(query, [date, todayData]);
     };
     // await executeJob();
-    schedule.scheduleJob("0 30 2 * * *", executeJob);
+    schedule.scheduleJob("0 0 0 * * *", executeJob);
 };
 
 const realCode = [
@@ -153,7 +153,7 @@ const doKIS = async () => {
         }
     };
     // await executeJob();
-    schedule.scheduleJob("0 48 2 * * *", executeJob); //한국시간 기준으로 변경
+    schedule.scheduleJob("0 0 8 * * *", executeJob); //한국시간 기준으로 작성
 };
 
 const doHoly = async () => {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/feat/holiday -> develop

### 변경 사항
주말인 경우에도 DB holiday 테이블에 추가하고, 공휴일인 경우 주가 데이터 요청을 하지 않게끔 수정했습니다.
평일 기준, 전날이 주말 혹은 공휴일인 경우, 날짜를 하루씩 앞당기며 가장 최근 주식 장이 열린 날짜를 찾습니다.

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/b752711a-dc22-423b-8db3-a1124b60f723)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/34f4c4ca-4c22-463b-8ed8-8f88f7064b46)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/1b9c00be-f5f8-439b-bb46-87d54be80f77)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/9d11333c-8f8c-4613-9d7b-e1b618ed2170)

