### PR TITLE
[UPDATE] 퀴즈 정답 보상 중복 적용 해결

### DIFF
--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -63,13 +63,13 @@ router.patch("/answer", async (req, res) => {
         await pool.query(answerQuery, [isCorrect, req.userId, yesterday]);
 
         // 맞았을 경우 사용자의 pdi 추가
-        if (isCorrect) {
+        if (isCorrect && !userResponse[0].is_checked) {
             const addPointQuery = `UPDATE hold_stock SET avg_price = avg_price + 500 WHERE user_id = ? AND stock_id = 10`;
             await pool.query(addPointQuery, [req.userId]);
         }
 
         res.send({
-            code: userResponse[0].is_checked ? 2 : 1,
+            code: userResponse[0].is_checked ? 2 : 1, // 이미 조회했으면 2
             stockCode: userResponse[0].stock_id, // 고른 종목 코드
             stockName: answerResponse[0].stock_name, // 고른 종목 이름
             yesterdayCost: answerResponse[0].yesterday_cost,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/fix/quiz-answer -> develop

### 변경 사항
이미 보상이 적용 된 후에도, 정답 확인 시 반복적으로 보상이 지급되는 현상을 수정하였습니다.

### 테스트 결과
실행 전
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/56144f5e-5839-4a6f-b3cd-4fcf2b2f52b0)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/a50fb7d6-9076-4a1a-8fa4-0bcac6f7e454)

1회 실행(맞은 경우)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/753cd944-342b-4854-8d58-7e363744a572)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/d5de51c2-5697-4ef7-97f4-a40a23bc4326)

2회 실행(맞은 경우)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/a93fe563-4ee1-439b-a515-da2d2caf4c5b)
