### PR TITLE
[FIX] 서버 - 퀴즈 응답 한번만 저장되도록 변경

### DIFF
--- a/server/routes/api/quiz.js
+++ b/server/routes/api/quiz.js
@@ -15,6 +15,14 @@ router.post("/response", async (req, res) => {
         const date = req.body.date;
         const upDown = req.body.upDown;
 
+        const checkQuery = `SELECT count(*) as cnt from quiz WHERE user_id = ? AND date = ?`;
+        const [check] = await pool.query(checkQuery, [userId, date]);
+        console.log(check[0].cnt);
+        if (check[0].cnt > 0) {
+            res.send({ code: 0 });
+            return;
+        }
+
         const resQuery = `INSERT INTO quiz (user_id, stock_id, date, up_down) VALUES (?, ?, ?, ?)`;
         const [result] = await pool.query(resQuery, [
             userId,
@@ -23,7 +31,9 @@ router.post("/response", async (req, res) => {
             upDown,
         ]);
         console.log(result.affectedRows);
-        res.send(result.affectedRows + "개의 레코드가 추가되었습니다");
+        res.send({
+            code : 1,
+            message : result.affectedRows + "개의 레코드가 추가되었습니다"});
     } catch (err) {
         console.log(err);
         res.send(err);
@@ -99,14 +109,15 @@ router.get("/content", async (req, res) => {
 router.get("/:date", async (req, res) => {
     //TODO : 오늘이 공휴일인지 확인
     try {
-        const holiQuery = `SELECT COUNT(*) AS count, date_name FROM holiday WHERE date = ?;`
+        const holiQuery = `SELECT COUNT(*) AS count, date_name FROM holiday WHERE date = ?;`;
         const [result] = await pool.query(holiQuery, [req.params.date]);
-        const isHoly = result[0].count>0 ? 1 : 0;
-        if(isHoly) res.send({
-            isHoly : isHoly,
-            date_name : result[0].date_name
-        });
-        else res.send({isHoly : isHoly});
+        const isHoly = result[0].count > 0 ? 1 : 0;
+        if (isHoly)
+            res.send({
+                isHoly: isHoly,
+                date_name: result[0].date_name,
+            });
+        else res.send({ isHoly: isHoly });
     } catch (e) {
         console.log(e);
         res.send("ERROR : " + e);

--- a/server/utils/schedule.js
+++ b/server/utils/schedule.js
@@ -158,7 +158,7 @@ const doKIS = async () => {
         }
     };
     // await executeJob();
-    schedule.scheduleJob("0 0 8 * * *", executeJob); //한국시간 기준으로 작성
+    schedule.scheduleJob("0 0 7 * * *", executeJob); //한국시간 기준으로 작성
 };
 
 const doHoly = async () => {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/be/fix/quiz/response-once -> develop

### 변경 사항
퀴즈 응답이 한번만 저장되도록 변경했습니다.
두 번째부터는 코드가 0이 반환됩니다.

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/f1ff9c0a-4d43-47ce-a02c-a6497d075616)
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/0e35b338-25f9-4c4a-bec6-65bd36e28811)
