### PR TITLE
[UPDATE] 퀴즈 응답 두 번 이상 저장 시 에러 알럿 표현

### DIFF
--- a/front/src/routes/main/Quiz.jsx
+++ b/front/src/routes/main/Quiz.jsx
@@ -52,7 +52,11 @@ const Quiz = () => {
 
     const postAnswer = async () => {
         const result = await UpdateQuiz(stockId, date, upDown);
-        Toast.fire("성공적으로 저장되었습니다!", "", "success");
+        console.log(result.code);
+        if(result.code === 0) {
+            Toast.fire("오늘의 퀴즈를 이미 풀었습니다!", "", "error");    
+        }
+        else Toast.fire("성공적으로 저장되었습니다!", "", "success");
     };
 
     const checkAnswer = async () => {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev/fe/fix/quiz/response-once -> develop

### 변경 사항
퀴즈 응답 두 번 이상 저장 시 에러 알럿으로 표현했습니다.

### 테스트 결과
![image](https://github.com/PDA-4-1/StockForest/assets/116863184/fa62201d-c9e5-437a-9692-173cad22ad3f)